### PR TITLE
fix: usec: iso9660/udf mount with useccontext failed in deepin.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+udisks2 (2.10.1-6deepin6) unstable; urgency=medium
+
+  * fix: usec: iso9660/udf mount with useccontext failed in deepin.
+  *     deepin社区版iso挂载选项usececontext挂载失败
+  *     Bug: https://pms.uniontech.com/bug-view-306521.html
+
+ -- zhangya <zhangya@uniontech.com>  Wed, 05 Mar 2025 19:14:08 +0800
+
 udisks2 (2.10.1-6deepin5) unstable; urgency=medium
 
   * merge v20 patch.

--- a/debian/patches/usec-udisks2-mac-patches.patch
+++ b/debian/patches/usec-udisks2-mac-patches.patch
@@ -212,7 +212,7 @@ index 95a0aa8..65124ed 100644
                                                    shared_fs);
  
 +  // add cdrom audit  zhangya@uniontech.com
-+  if( strcmp(fs_type, "iso9660") == 0 || strcmp(fs_type, "udf") == 0 ){
++  if (strcmp(fs_type, "iso9660") == 0 || strcmp(fs_type, "udf") == 0 && access("/proc/1/attr/usid", F_OK) == 0) {
 +    g_variant_iter_init (&iter, options_to_use);
 +    g_variant_builder_init (&builder, G_VARIANT_TYPE("a{ss}"));
 +    while (g_variant_iter_next (&iter, "{&s&s}", &key, &value)) {


### PR DESCRIPTION
     deepin社区版iso挂载选项usececontext挂载失败
     Bug: https://pms.uniontech.com/bug-view-306521.html