### PR TITLE
fix: usec: iso9660/udf mount failed in sw/mips kernel without usec=1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+udisks2 (2.10.1-6deepin8) unstable; urgency=medium
+
+  * fix: usec: iso9660/udf mount failed in sw/mips kernel without usec=1
+
+ -- zhangya <zhangya@uniontech.com>  Tue, 22 Apr 2025 13:23:49 +0800
+
 udisks2 (2.10.1-6deepin7) unstable; urgency=medium
 
   * fix: error log make crash.

--- a/debian/patches/usec-udisks2-mac-patches.patch
+++ b/debian/patches/usec-udisks2-mac-patches.patch
@@ -212,7 +212,7 @@ index 95a0aa8..65124ed 100644
                                                    shared_fs);
  
 +  // add cdrom audit  zhangya@uniontech.com
-+  if ((strcmp(fs_type, "iso9660") == 0 || strcmp(fs_type, "udf") == 0) && access("/proc/1/attr/usid", F_OK) == 0) {
++  if ((strcmp(fs_type, "iso9660") == 0 || strcmp(fs_type, "udf") == 0) && access("/sys/fs/usec", F_OK) == 0) {
 +    g_variant_iter_init (&iter, options_to_use);
 +    g_variant_builder_init (&builder, G_VARIANT_TYPE("a{ss}"));
 +    while (g_variant_iter_next (&iter, "{&s&s}", &key, &value)) {


### PR DESCRIPTION
    https://pms.uniontech.com/bug-view-308915.html
    https://pms.uniontech.com/bug-view-306843.html
    https://pms.uniontech.com/bug-view-309313.html
    https://pms.uniontech.com/bug-view-306739.html